### PR TITLE
Fixed Additional Entries Future Log Bug

### DIFF
--- a/source/Frontend/scripts/router.js
+++ b/source/Frontend/scripts/router.js
@@ -254,6 +254,7 @@ function futureLog(){
     }
 
     createFutureNav(d);
+    updateAddlEntries();
 } /* futureLog */
 
 /**


### PR DESCRIPTION
- What was changed?
  - Additional entries now correctly update when user is on the future log.

- How was it changed? (put specific specs here)
  - Added missing function used to update addl. entries.


- Any special notes?
  - N/A

@michl1001
@derek-hwang27